### PR TITLE
Update to 1.0.0, numerous fixes

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/js/placespeak.js
+++ b/js/placespeak.js
@@ -43,7 +43,8 @@ $.ajax({
                 $('#placespeak_connect_button').hide();
                 // Loading Leaflet
                 var map = L.map('placespeak_plugin_map', { zoomControl:false }).setView([51.505, -0.09], 13);
-                L.tileLayer('http://api.tiles.mapbox.com/v4/victorplacespeak.cig2i6les1d5kt4kx6sveyeyu/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoidmljdG9ycGxhY2VzcGVhayIsImEiOiJjaWcyaTZteG8xZGl1dTNtNHEzZjdiazlqIn0.KUYzQqUkEAhAaqi0LPMSpQ', {
+                
+                L.tileLayer('https://api.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoicGxhY2VzcGVhayIsImEiOiJjaWw0YnJvdTIzeDY3dXlrczY3YmRlMGU3In0.X9KRXYQzCQMVIhYqrI4RaQ', {
                     //attribution: 'Imagery from <a href="http://mapbox.com/about/maps/">MapBox</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                     subdomains: 'abcd',
                     maxZoom: 19

--- a/oauth_redirect.php
+++ b/oauth_redirect.php
@@ -31,10 +31,16 @@ require_once( dirname(dirname(dirname( dirname( __FILE__ ) ) ) ) . '/wp-load.php
  */
 global $wpdb;
 $table_name = $wpdb->prefix . 'placespeak';
-$client_info = $wpdb->get_row("SELECT * FROM " . $table_name . " WHERE id = " . $app_id);
+$query_array = [$app_id];
+$client_info = $wpdb->get_row(
+    $wpdb->prepare(
+        "SELECT * FROM " . $table_name . " WHERE id = %d",
+        $query_array
+    )
+);
 $client_id = $client_info->client_key;
 $client_secret = $client_info->client_secret;
-$redirect_uri = $client_info->redirect_uri . '/wp-content/plugins/wp-placespeak-connect/oauth_redirect.php';
+$redirect_uri = plugin_dir_url(__FILE__) . 'oauth_redirect.php';
 
 /**
  * If request has returned a code, then send the authorization request with cURL

--- a/placespeak.php
+++ b/placespeak.php
@@ -615,14 +615,14 @@ function ps_select_placespeak_app() {
 function ps_placespeak_scripts() {
     wp_register_script( 'leaflet-js', plugin_dir_url(__FILE__) . 'js/leaflet.js', array('jquery'));
     wp_register_script( 'polyline-encoded-js', plugin_dir_url(__FILE__) . 'js/polyline.encoded.js', array('jquery','leaflet-js'));
-    wp_register_script( 'placespeak-js', plugin_dir_url(__FILE__) . 'js/placespeak.js', array('jquery','leaflet-js','polyline-encoded-js'),'1.0.20');
+    wp_register_script( 'placespeak-js', plugin_dir_url(__FILE__) . 'js/placespeak.js', array('jquery','leaflet-js','polyline-encoded-js'),'1.0.21');
 
     wp_enqueue_style( 'leaflet-css', plugin_dir_url(__FILE__) . 'css/leaflet.css' );
     wp_enqueue_style( 'placespeak-css', plugin_dir_url(__FILE__) . 'css/placespeak.css' );
 
     wp_enqueue_script( 'leaflet-js', plugin_dir_url(__FILE__) . 'js/leaflet.js', array('jquery'),'0.7.7',false);
     wp_enqueue_script( 'polyline-encoded-js', plugin_dir_url(__FILE__) . 'js/polyline.encoded.js', array('leaflet-js'),'0.13',false);
-    wp_enqueue_script( 'placespeak-js', plugin_dir_url(__FILE__) . 'js/placespeak.js', array('jquery','leaflet-js','polyline-encoded-js'),'1.0.20',true);
+    wp_enqueue_script( 'placespeak-js', plugin_dir_url(__FILE__) . 'js/placespeak.js', array('jquery','leaflet-js','polyline-encoded-js'),'1.0.21',true);
 }
 
 add_action( 'wp_enqueue_scripts', 'ps_placespeak_scripts' );

--- a/signed_in_ajax.php
+++ b/signed_in_ajax.php
@@ -65,7 +65,13 @@ if($user_id) {
     if($user_storage == 'PS_USERS') {
         global $wpdb;
         $table_name = $wpdb->prefix . 'placespeak_users';
-        $user_info = $wpdb->get_results("SELECT * FROM " . $table_name . " WHERE user_id = " . $user_id);
+        $query_array = [$user_id];
+        $user_info = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM " . $table_name . " WHERE user_id = %d",
+                $query_array
+            )
+        );
         if($user_info) {
             // Check to see which index number this app is for this user, and get specific geo_labels (stored in DB as arrays separated by vertical bars)
             $authorized_client_keys = explode(',',get_user_meta($wordpress_user_id,'placespeak_authorized_client_key', true));

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * When populating this file, consider the following flow
+ * of control:
+ *
+ * - This method should be static
+ * - Check if the $_REQUEST content actually is the plugin name
+ * - Run an admin referrer check to make sure it goes through authentication
+ * - Verify the output of $_GET makes sense
+ * - Repeat with other user roles. Best directly by using the links/query string parameters.
+ * - Repeat things for multisite. Once for a single site in the network, once sitewide.
+ *
+ * This file may be updated more in future version of the Boilerplate; however, this is the
+ * general skeleton and outline for how the file should work.
+ *
+ * For more information, see the following discussion:
+ * https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/pull/123#issuecomment-28541913
+ *
+ * @link       http://tempranova.com
+ * @since      1.0.0
+ *
+ * @package    comment-load-more
+ */
+// If uninstall not called from WordPress, then exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}


### PR DESCRIPTION
- Plugin refers to itself now, not site + wp-content/
- Any SQL query taking input from the DOM originally now uses prepared
statements
- Redirect URL removed from DB storage, printed in settings instead
- Option added to show user area metadata on front end of comment
- Comment label area(s) shows on front end if selected
- BUG fixed where map showed even if user didn’t exist yet in the DB
- A few small WP plugin things (index.php, uninstall.php)

Fixes still needed
- Update Mapbox reference to PS
- Appearance and wording of front end metadata